### PR TITLE
Fixed the bug where examples found by hiragana reading were not highligh...

### DIFF
--- a/japanese_examples.py
+++ b/japanese_examples.py
@@ -156,9 +156,14 @@ def find_examples(expression, maxitems):
                 color_example = content[j+1]
                 regexp = "(?:\(*%s\)*)(?:\([^\s]+?\))*(?:\[\d+\])*\{(.+?)\}" %expression
                 match = re.compile("%s" %regexp).search(color_example)
+                regexp_reading = "(?:\s([^\s]*?))(?:\(%s\))" % expression
+                match_reading = re.search(regexp_reading, color_example)
                 if match:
                     expression_bis = match.group(1)
                     example = example.replace(expression_bis,'<FONT COLOR="#ff0000">%s</FONT>' %expression_bis)
+                elif match_reading:
+                    expression_bis = match_reading.group(1)
+                    example = example.replace(expression_bis,'<FONT COLOR="#ff0000">%s</FONT>' %expression_bis) 
                 else:
                     example = example.replace(expression,'<FONT COLOR="#ff0000">%s</FONT>' %expression)
                 examples.append("<br>%s<br>%s<br>" % tuple(example.split('\t')))


### PR DESCRIPTION
For examples, that are found via the hiragana reading in round brackets, the corresponding kanzi was not highlighted. I have fixed this, so that the words are properly highlighted in red.

Example:
For expression "れい", an example sentence "これで彼の霊も浮かばれるだろう。" will be pulled, as the color_example includes "霊(れい)", but "霊" is not highlighted.
With the fix, it properly shows the sentence with "霊" highlighted in red.
