### PR TITLE
Dont' load examples if maxShow == 0

### DIFF
--- a/config.md
+++ b/config.md
@@ -1,4 +1,4 @@
-*maxShow*: Amount of examples to temporarily show when this add-on is loaded
+*maxShow*: Amount of examples to temporarily show when this add-on is loaded. If set to 0, then examples won't be loaded automatically (only the values already in the fields will be used).
 
 *maxPermanent* Amount to add permanently to the Examples field
 

--- a/japanese_examples.py
+++ b/japanese_examples.py
@@ -175,6 +175,9 @@ class NoExamplesFoundException(Exception):
 
 
 def find_examples_multiple(n, maxitems, modelname=""):
+    if maxitems == 0:
+        raise NoExamplesFoundException()
+
     if not modelname:
         modelname = n.model()['name'].lower()
 


### PR DESCRIPTION
Fixes #5 

## Before this PR

There was no way to prevent the plugin from dynamically loading examples when the card is rendered.

## After this PR

Setting `maxShow` to 0 forces the plugin to rely on the already-populated sentence fields.